### PR TITLE
애플 로그인 구현

### DIFF
--- a/howgoods/howgoods/Common/Utils/Extensions/Bundle+.swift
+++ b/howgoods/howgoods/Common/Utils/Extensions/Bundle+.swift
@@ -1,0 +1,20 @@
+//
+//  Bundle+.swift
+//  howgoods
+//
+//  Created by 양원식 on 8/3/25.
+//
+
+import Foundation
+
+extension Bundle {
+    
+    /// Info.plist에서 BASE_API_URL을 읽어오는 컴퓨티드 프로퍼티
+    var baseAPIURL: URL {
+        guard let urlString = object(forInfoDictionaryKey: "BASE_API_URL") as? String,
+              let url = URL(string: urlString) else {
+            fatalError("BASE_API_URL이 Info.plist에 설정되어 있지 않거나 잘못된 형식입니다.")
+        }
+        return url
+    }
+}

--- a/howgoods/howgoods/Common/Utils/Extensions/UIView+.swift
+++ b/howgoods/howgoods/Common/Utils/Extensions/UIView+.swift
@@ -1,0 +1,16 @@
+//
+//  UIView+.swift
+//  howgoods
+//
+//  Created by 양원식 on 8/3/25.
+//
+
+import UIKit
+
+extension UIView {
+    func addSubviews(_ views: UIView...) {
+        views.forEach {
+            self.addSubview($0)
+        }
+    }
+}

--- a/howgoods/howgoods/Data/Network/AuthRouter.swift
+++ b/howgoods/howgoods/Data/Network/AuthRouter.swift
@@ -22,7 +22,7 @@ enum AuthRouter: URLRequestConvertible {
     var path: String {
         switch self {
         case .loginWithApple:
-            return "/api/auth/apple"
+            return "/api/auth/apple/callback"
         // TODO: case .loginWithNaver:
         //   return "/api/auth/naver"
         }

--- a/howgoods/howgoods/Data/Network/AuthRouter.swift
+++ b/howgoods/howgoods/Data/Network/AuthRouter.swift
@@ -1,0 +1,45 @@
+//
+//  AuthRouter.swift
+//  howgoods
+//
+//  Created by 양원식 on 8/3/25.
+//
+
+import Alamofire
+import Foundation
+
+/// 인증 관련 API 요청의 스펙을 정의하는 라우터
+enum AuthRouter: URLRequestConvertible {
+    
+    /// Apple 로그인 요청 (authorization code 전송)
+    case loginWithApple(code: String)
+    
+    // TODO: case loginWithGoogle(token: String)
+    // TODO: case loginWithKakao(token: String)
+
+    var method: HTTPMethod { .post }
+
+    var path: String {
+        switch self {
+        case .loginWithApple:
+            return "/api/auth/apple"
+        // TODO: case .loginWithNaver:
+        //   return "/api/auth/naver"
+        }
+    }
+
+    func asURLRequest() throws -> URLRequest {
+        let url = Bundle.main.baseAPIURL
+        
+        var request = URLRequest(url: url.appendingPathComponent(path))
+        request.method = method
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        switch self {
+        case .loginWithApple(let code):
+            request.httpBody = try JSONEncoder().encode(["code": code])
+        }
+
+        return request
+    }
+}

--- a/howgoods/howgoods/Data/Repositories/AuthRepository.swift
+++ b/howgoods/howgoods/Data/Repositories/AuthRepository.swift
@@ -1,0 +1,38 @@
+//
+//  AuthRepository.swift
+//  howgoods
+//
+//  Created by 양원식 on 8/3/25.
+//
+import RxSwift
+
+final class AuthRepository: AuthRepositoryProtocol {
+
+    private let appleAuthService: AppleAuthService
+    private let authNetworkService: AuthNetworkService
+
+    init(
+        appleAuthService: AppleAuthService,
+        authNetworkService: AuthNetworkService
+    ) {
+        self.appleAuthService = appleAuthService
+        self.authNetworkService = authNetworkService
+    }
+
+    func loginWithApple() -> Observable<Result<String, Error>> {
+        return appleAuthService.authorizeWithApple()
+    }
+
+    func sendCodeToServer(code: String) -> Observable<Result<String, Error>> {
+        return authNetworkService.loginWithApple(code: code)
+            .map { result in
+                switch result {
+                case .success(let tokenEntity):
+                    return .success(tokenEntity.token)
+                case .failure(let error):
+                    return .failure(error)
+                }
+            }
+    }
+}
+

--- a/howgoods/howgoods/Data/Service/AppleAuthService.swift
+++ b/howgoods/howgoods/Data/Service/AppleAuthService.swift
@@ -1,0 +1,49 @@
+//
+//  AppleAuthService.swift
+//  howgoods
+//
+//  Created by 양원식 on 8/3/25.
+//
+
+import AuthenticationServices
+import RxSwift
+
+final class AppleAuthService: NSObject {
+    private let authorizationSubject = PublishSubject<Result<String, Error>>()
+
+    func authorizeWithApple() -> Observable<Result<String, Error>> {
+        let request = ASAuthorizationAppleIDProvider().createRequest()
+        request.requestedScopes = [.email]
+
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        controller.delegate = self
+        controller.presentationContextProvider = self
+        controller.performRequests()
+
+        return authorizationSubject.asObservable()
+    }
+}
+
+extension AppleAuthService: ASAuthorizationControllerDelegate {
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+              let codeData = credential.authorizationCode,
+              let code = String(data: codeData, encoding: .utf8) else {
+            authorizationSubject.onNext(.failure(NSError(domain: "AppleAuth", code: -1)))
+            return
+        }
+        authorizationSubject.onNext(.success(code))
+        authorizationSubject.onCompleted()
+    }
+
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        authorizationSubject.onNext(.failure(error))
+        authorizationSubject.onCompleted()
+    }
+}
+
+extension AppleAuthService: ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return UIApplication.shared.windows.first { $0.isKeyWindow } ?? ASPresentationAnchor()
+    }
+}

--- a/howgoods/howgoods/Data/Service/AuthNetworkService.swift
+++ b/howgoods/howgoods/Data/Service/AuthNetworkService.swift
@@ -1,0 +1,36 @@
+//
+//  AppleAuthService.swift
+//  howgoods
+//
+//  Created by 양원식 on 8/3/25.
+//
+
+import AuthenticationServices
+import RxSwift
+import Alamofire
+
+final class AuthNetworkService: AuthNetworkServiceProtocol {
+    func loginWithApple(code: String) -> Observable<Result<AuthToken, Error>> {
+        return Observable.create { observer in
+            let router = AuthRouter.loginWithApple(code: code)
+
+            AF.request(router)
+                .validate()
+                .responseDecodable(of: AuthToken.self) { response in
+                    switch response.result {
+                    case .success(let token):
+                        observer.onNext(.success(token))
+                    case .failure(let error):
+                        observer.onNext(.failure(error))
+                    }
+                    observer.onCompleted()
+                }
+
+            return Disposables.create()
+        }
+    }
+    
+    // TODO: loginWithNaver
+    
+    // TODO: loginWithKakao
+}

--- a/howgoods/howgoods/Data/Service/Protocol/AppleAuthServiceProtocol.swift
+++ b/howgoods/howgoods/Data/Service/Protocol/AppleAuthServiceProtocol.swift
@@ -1,0 +1,14 @@
+//
+//  AppleAuthServiceProtocol.swift
+//  howgoods
+//
+//  Created by 양원식 on 8/3/25.
+//
+
+import RxSwift
+
+/// 인증 관련 네트워크 요청을 담당하는 서비스 계층
+protocol AuthNetworkServiceProtocol {
+    func loginWithApple(code: String) -> Observable<Result<AuthToken, Error>>
+    // TODO: loginWithNaver(token: String), loginWithKakao(token: String)
+}

--- a/howgoods/howgoods/Domain/Entities/AuthToken.swift
+++ b/howgoods/howgoods/Domain/Entities/AuthToken.swift
@@ -1,0 +1,12 @@
+//
+//  LoginResponse.swift
+//  howgoods
+//
+//  Created by 양원식 on 8/3/25.
+//
+
+/// 로그인 응답 모델
+struct AuthToken: Decodable, Equatable {
+    // 서버에서 발급받는 인증 토큰
+    let token: String
+}

--- a/howgoods/howgoods/Domain/Entities/LoginType.swift
+++ b/howgoods/howgoods/Domain/Entities/LoginType.swift
@@ -1,0 +1,15 @@
+//
+//  LoginType.swift
+//  howgoods
+//
+//  Created by 양원식 on 8/3/25.
+//
+
+/// 로그인 타입을 구분하는 열거형
+enum LoginType {
+    case apple
+    case naver
+    case kakao
+    
+    // TODO: 추후 naver, Kakao 로그인 추가 시 분기 처리에 사용
+}

--- a/howgoods/howgoods/Domain/Interfaces/Repositories/AuthRepositoryProtocol.swift
+++ b/howgoods/howgoods/Domain/Interfaces/Repositories/AuthRepositoryProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  AuthRepositoryProtocol.swift
+//  howgoods
+//
+//  Created by 양원식 on 8/3/25.
+//
+
+import RxSwift
+
+protocol AuthRepositoryProtocol {
+    func loginWithApple() -> Observable<Result<String, Error>>
+    func sendCodeToServer(code: String) -> Observable<Result<String, Error>>
+}

--- a/howgoods/howgoods/Domain/Interfaces/UseCases/LoginUseCase.swift
+++ b/howgoods/howgoods/Domain/Interfaces/UseCases/LoginUseCase.swift
@@ -1,0 +1,45 @@
+//
+//  LoginWithAppleUseCase.swift
+//  howgoods
+//
+//  Created by 양원식 on 8/3/25.
+//
+
+import RxSwift
+import Foundation
+
+final class LoginUseCase: LoginUseCaseProtocol {
+
+    private let appleAuthRepository: AuthRepository
+    // TODO: private let naverAuthRepository: AuthRepository
+    // TODO: private let kakaoAuthRepository: AuthRepository
+
+    init(
+        appleAuthRepository: AuthRepository
+        // TODO: naverAuthRepository: AuthRepository
+    ) {
+        self.appleAuthRepository = appleAuthRepository
+    }
+
+    func execute(type: LoginType) -> Observable<Result<String, Error>> {
+        switch type {
+        case .apple:
+            return appleAuthRepository.loginWithApple()
+                .flatMap { result -> Observable<Result<String, Error>> in
+                    switch result {
+                    case .success(let code):
+                        return self.appleAuthRepository.sendCodeToServer(code: code)
+                    case .failure(let error):
+                        return .just(.failure(error))
+                    }
+                }
+
+        // TODO: case .naver:
+        //   return naverAuthRepository.loginWithNaver()...
+
+        default:
+            return .just(.failure(NSError(domain: "Unsupported LoginType", code: -999)))
+        }
+    }
+}
+

--- a/howgoods/howgoods/Domain/UseCases/LoginUseCaseProtocol.swift
+++ b/howgoods/howgoods/Domain/UseCases/LoginUseCaseProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  LoginWithAppleUseCase.swift
+//  howgoods
+//
+//  Created by 양원식 on 8/3/25.
+//
+
+import RxSwift
+
+protocol LoginUseCaseProtocol {
+    func execute(type: LoginType) -> Observable<Result<String, Error>>
+}

--- a/howgoods/howgoods/Presentation/Login/View/LoginView.swift
+++ b/howgoods/howgoods/Presentation/Login/View/LoginView.swift
@@ -1,0 +1,71 @@
+//
+//  LoginView.swift
+//  howgoods
+//
+//  Created by 양원식 on 8/3/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+import AuthenticationServices
+
+final class LoginView: UIView {
+    // MARK: - Properties
+    
+    // MARK: - UI Components
+    private let appleLoginButton = ASAuthorizationAppleIDButton().then {
+        $0.cornerRadius = 8
+        $0.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    // MARK: - Getter
+    var getAppleLoginButton: ASAuthorizationAppleIDButton {
+        return appleLoginButton
+    }
+
+    // MARK: - Initializer
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configure()
+    }
+    
+    @available(*, unavailable, message: "storyboard is not supported.")
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented.")
+    }
+    
+    // MARK: - Public Methods
+}
+
+private extension LoginView {
+    // MARK: - configure
+    func configure() {
+        setHierarchy()
+        setStyles()
+        setConstraints()
+    }
+    
+    // MARK: - setHierarchy
+    func setHierarchy() {
+        addSubviews(
+            appleLoginButton
+        )
+    }
+    
+    // MARK: - setStyles
+    func setStyles() {
+        backgroundColor = .white
+    }
+    
+    // MARK: - setConstraints
+    func setConstraints() {
+        appleLoginButton.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(40)
+            $0.height.equalTo(50)
+            $0.width.equalTo(280)
+        }
+    }
+}

--- a/howgoods/howgoods/Presentation/Login/View/LoginViewController.swift
+++ b/howgoods/howgoods/Presentation/Login/View/LoginViewController.swift
@@ -6,40 +6,45 @@
 //
 
 import UIKit
+import AuthenticationServices
+import RxSwift
+import RxCocoa
 
 final class LoginViewController: UIViewController {
     
     // MARK: - Properties
-    
-    //private let viewModel: <#ViewModel#>
-    
-    // MARK: - Lifecycle
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        configure()
-    }
+    private let loginView = LoginView()
+    private let viewModel: LoginViewModel
+    private let disposeBag = DisposeBag()
     
     // MARK: - Initializer
     
-    init() {
+    init(viewModel: LoginViewModel) {
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
     
-    @available(*, unavailable, message: "compile error")
+    @available(*, unavailable, message: "Storyboard is not supported")
     required init?(coder: NSCoder) {
         fatalError()
     }
     
-    @objc
-    func didTapSomeButton(_ sender: UIButton) {
-        
+    // MARK: - Lifecycle
+    
+    override func loadView() {
+        self.view = loginView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configure()
     }
 }
 
 // MARK: - UI Methods
 
 private extension LoginViewController {
+    
     func configure() {
         setHierarchy()
         setStyles()
@@ -47,14 +52,11 @@ private extension LoginViewController {
         setActions()
         setBinding()
     }
-    // ...
     
-    // MARK: - setBinding
     func setHierarchy() { }
     func setStyles() { }
     func setConstraints() { }
     func setActions() { }
     func setBinding() { }
-    
 }
 

--- a/howgoods/howgoods/Presentation/Login/View/LoginViewController.swift
+++ b/howgoods/howgoods/Presentation/Login/View/LoginViewController.swift
@@ -57,6 +57,21 @@ private extension LoginViewController {
     func setStyles() { }
     func setConstraints() { }
     func setActions() { }
-    func setBinding() { }
+    func setBinding() {
+        loginView.getAppleLoginButton.rx.controlEvent(.touchUpInside)
+            .bind(to: viewModel.appleLoginTapped)
+            .disposed(by: disposeBag)
+
+        viewModel.loginResult
+            .drive(onNext: { result in
+                switch result {
+                case .success(let token):
+                    print("로그인 성공: \(token)")
+                case .failure(let error):
+                    print("로그인 실패: \(error.localizedDescription)")
+                }
+            })
+            .disposed(by: disposeBag)
+    }
 }
 

--- a/howgoods/howgoods/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/howgoods/howgoods/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -1,0 +1,52 @@
+//
+//  LoginViewModel.swift
+//  howgoods
+//
+//  Created by 양원식 on 8/3/25.
+//
+
+import RxSwift
+import RxCocoa
+import Foundation
+
+// MARK: - Input / Output Protocol
+
+protocol LoginViewModelInput {
+    var appleLoginTapped: PublishRelay<Void> { get }
+    // TODO: var naverLoginTapped: PublishRelay<Void> { get }
+}
+
+protocol LoginViewModelOutput {
+    var loginResult: Driver<Result<String, Error>> { get }
+}
+
+// MARK: - ViewModel
+
+final class LoginViewModel: LoginViewModelInput, LoginViewModelOutput {
+
+    // MARK: - Input
+    let appleLoginTapped = PublishRelay<Void>()
+
+    // MARK: - Output
+    let loginResult: Driver<Result<String, Error>>
+
+    // MARK: - Dependencies
+    private let loginUseCase: LoginUseCase
+    private let disposeBag = DisposeBag()
+
+    // MARK: - Init
+    init(loginUseCase: LoginUseCase) {
+        self.loginUseCase = loginUseCase
+
+        let result = PublishRelay<Result<String, Error>>()
+
+        appleLoginTapped
+            .map { LoginType.apple } // 명시적으로 Apple 타입 전달
+            .flatMapLatest { loginUseCase.execute(type: $0) }
+            .bind(to: result)
+            .disposed(by: disposeBag)
+
+        self.loginResult = result
+            .asDriver(onErrorJustReturn: .failure(NSError(domain: "", code: -1)))
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #1 

<br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- Apple 로그인 기능 구현
   - Apple ID 인증 요청 및 authorization code 추출 (AppleAuthService)
   - authorization code를 서버에 전송 (AuthNetworkService, AuthRouter)
   - 토큰 응답 수신 및 ViewModel 바인딩 (LoginUseCase, LoginViewModel)
   - MVVM-C + Clean Architecture 기반 분리
   - Info.plist의 BASE_API_URL 설정을 통해 서버 주소 관리

- 확인이 필요한 내용
   - Apple 로그인 API (/api/auth/apple)와의 통신 연동이 실제 서버 환경에서 정상적으로 작동하는지 확인 필요
   - 서버에서 authorizationCode를 정상 처리하는지 확인 필요

<br>

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/84ef32ee-256a-4014-a1b7-5aa661c6cb25" width ="250"> |

<br>
