### PR TITLE
NetworkError 타입 불일치로 인한 컴파일 에러 수정

### DIFF
--- a/howgoods/howgoods/Data/DTO/Response/AuthResponseDTO.swift
+++ b/howgoods/howgoods/Data/DTO/Response/AuthResponseDTO.swift
@@ -23,7 +23,7 @@
 struct AuthResponseDTO: Decodable {
     
     /// 요청 처리 성공 여부
-    let success: Bool
+    let success: Bool?
     
     /// HTTP 상태 코드 또는 서버 정의 응답 코드
     let code: Int
@@ -32,8 +32,8 @@ struct AuthResponseDTO: Decodable {
     let message: String
     
     /// 유효성 검사 실패 시 서버에서 내려주는 상세 오류 메시지 (선택적)
-    let validationErrors: String?
+    let validationErrors: [String: [String]]?
     
     /// 인증 관련 실제 데이터 (ex. access token 등)
-    let data: AuthTokenDTO
+    let data: AuthTokenDTO?
 }

--- a/howgoods/howgoods/Data/DTO/Response/ErrorResponseDTO.swift
+++ b/howgoods/howgoods/Data/DTO/Response/ErrorResponseDTO.swift
@@ -24,7 +24,7 @@
 struct ErrorResponseDTO: Decodable {
     
     /// 요청 처리 성공 여부 (`false`일 경우 에러 응답)
-    let success: Bool
+    let success: Bool?
     
     /// 서버에서 정의한 에러 코드 (예: 400, 401, 422 등)
     let code: Int
@@ -36,5 +36,5 @@ struct ErrorResponseDTO: Decodable {
     ///
     /// - Key: 필드명 (예: "email", "password")
     /// - Value: 해당 필드의 오류 메시지
-    let validationErrors: [String: String]?
+    let validationErrors: [String: [String]]?
 }

--- a/howgoods/howgoods/Data/Service/AuthNetworkService.swift
+++ b/howgoods/howgoods/Data/Service/AuthNetworkService.swift
@@ -21,17 +21,17 @@ final class AuthNetworkService: AuthNetworkServiceProtocol {
     ///
     /// - Parameter code: Apple 로그인 후 발급받은 authorization code
     /// - Returns: 인증 성공 시 `AuthToken`, 실패 시 `Error`를 포함한 `Result`
-    func loginWithApple(code: String) -> Observable<Result<AuthToken, Error>> {
+    func loginWithApple(code: String) -> Observable<Result<AuthToken, NetworkError>> {
         return sendRequest(router: AuthRouter.loginWithApple(code: code))
     }
 
     /// Naver 로그인 인증 코드를 서버에 전송합니다.
-    func loginWithNaver(code: String) -> Observable<Result<AuthToken, Error>> {
+    func loginWithNaver(code: String) -> Observable<Result<AuthToken, NetworkError>> {
         return sendRequest(router: AuthRouter.loginWithNaver(code: code))
     }
 
     /// Kakao 로그인 인증 코드를 서버에 전송합니다.
-    func loginWithKakao(code: String) -> Observable<Result<AuthToken, Error>> {
+    func loginWithKakao(code: String) -> Observable<Result<AuthToken, NetworkError>> {
         return sendRequest(router: AuthRouter.loginWithKakao(code: code))
     }
 
@@ -41,7 +41,7 @@ final class AuthNetworkService: AuthNetworkServiceProtocol {
     ///
     /// - Parameter router: 요청 정보를 담고 있는 `AuthRouter`
     /// - Returns: 서버 응답을 도메인 모델로 변환한 `Observable<Result<AuthToken, Error>>`
-    private func sendRequest(router: URLRequestConvertible) -> Observable<Result<AuthToken, Error>> {
+    private func sendRequest(router: URLRequestConvertible) -> Observable<Result<AuthToken, NetworkError>> {
         return Observable.create { observer in
             AF.request(router)
                 .validate()
@@ -67,39 +67,42 @@ final class AuthNetworkService: AuthNetworkServiceProtocol {
 
                     // 응답 처리
                     switch response.result {
-                    case .success(let authResponseDTO):
-                        // 성공 시 도메인 모델로 변환
-                        let domainModel = authResponseDTO.data.toDomain()
-                        observer.onNext(.success(domainModel))
+                    case .success(let dto):
+                        guard dto.code == 200 else {
+                            observer.onNext(.failure(NetworkError.server(message: dto.message)))
+                            observer.onCompleted()
+                            return
+                        }
+                        guard let tokenDTO = dto.data else {
+                            observer.onNext(.failure(NetworkError.decoding)) // 스키마 불일치/누락
+                            observer.onCompleted()
+                            return
+                        }
+                        observer.onNext(.success(tokenDTO.toDomain()))
+                        observer.onCompleted()
 
-                    case .failure(_):
-                        // 상태 코드 기반 에러 처리
-                        if let responseCode = response.response?.statusCode {
-                            switch responseCode {
+                    case .failure(let afError):
+                        if let status = response.response?.statusCode {
+                            switch status {
                             case 401:
-                                observer.onNext(.failure(NetworkError.unauthorized))
-                                observer.onCompleted()
-                                return
-
+                                observer.onNext(.failure(.unauthorized)); observer.onCompleted(); return
                             case 408:
-                                observer.onNext(.failure(NetworkError.timeout))
-                                observer.onCompleted()
-                                return
-
-                            default:
-                                break
+                                observer.onNext(.failure(.timeout)); observer.onCompleted(); return
+                            default: break
                             }
                         }
 
-                        // 서버에서 내려준 에러 메시지 디코딩
                         if let data = response.data,
-                           let errorDTO = try? JSONDecoder().decode(ErrorResponseDTO.self, from: data) {
-                            observer.onNext(.failure(NetworkError.server(message: errorDTO.message)))
+                           let err = try? JSONDecoder().decode(ErrorResponseDTO.self, from: data) {
+                            observer.onNext(.failure(.server(message: err.message)))
+                        } else if case .responseSerializationFailed = afError.asAFError {
+                            // 디코딩/직렬화 실패는 명확히 표시
+                            observer.onNext(.failure(.decoding))
                         } else {
-                            observer.onNext(.failure(NetworkError.unknown))
+                            observer.onNext(.failure(.unknown))
                         }
-
                         observer.onCompleted()
+
                     }
                 }
 

--- a/howgoods/howgoods/Data/Service/NaverAuthService.swift
+++ b/howgoods/howgoods/Data/Service/NaverAuthService.swift
@@ -36,6 +36,7 @@ final class NaverAuthService {
         return Observable.create { observer in
             
             if self.oauth.accessToken != nil {
+                print("\(String(describing: self.oauth.accessToken))")
                 print("이미 로그인되어 있어 로그아웃 후 재시도합니다.")
                 self.oauth.logout()
             }

--- a/howgoods/howgoods/Data/Service/Protocol/AuthNetworkServiceProtocol.swift
+++ b/howgoods/howgoods/Data/Service/Protocol/AuthNetworkServiceProtocol.swift
@@ -19,15 +19,15 @@ protocol AuthNetworkServiceProtocol {
     ///
     /// - Parameter code: Apple 로그인 후 획득한 authorization code
     /// - Returns: 서버로부터 수신한 `AuthToken` 또는 `Error`
-    func loginWithApple(code: String) -> Observable<Result<AuthToken, Error>>
+    func loginWithApple(code: String) -> Observable<Result<AuthToken, NetworkError>>
 
     /// Naver 로그인 인증 코드를 서버에 전송하고 토큰을 반환합니다.
     ///
     /// - Parameter code: Naver 로그인 후 획득한 token
-    func loginWithNaver(code: String) -> Observable<Result<AuthToken, Error>>
+    func loginWithNaver(code: String) -> Observable<Result<AuthToken, NetworkError>>
 
     /// Kakao 로그인 인증 코드를 서버에 전송하고 토큰을 반환합니다.
     ///
     /// - Parameter code: Kakao 로그인 후 획득한 token
-    func loginWithKakao(code: String) -> Observable<Result<AuthToken, Error>>
+    func loginWithKakao(code: String) -> Observable<Result<AuthToken, NetworkError>>
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- PR과 연관된 이슈 번호를 작성해주세요 -->
- #13 

<br>

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- `AuthNetworkService`의 `Result` 실패 타입을 `NetworkError`로 변경
- `.unauthorized`, `.timeout` 등 `NetworkError` 케이스를 직접 사용할 수 있도록 수정
- `AuthResponseDTO`의 `data`를 옵셔널로 변경하여 디코딩 실패 방지